### PR TITLE
constructors from DataFrame and TimeArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ TArray(colpairs::Pair...)
 TArray(keynames::Tuple, colpairs::Pair...)
 TArray(data::NDSparse, keynames::Tuple, valnames::Tuple)
 TArray(from::TArray, colpairs::Pair...)
+TArray(from::TimeSeries.TimeArray)
+TArray(keynames::Tuple, from::TimeSeries.TimeArray)
+TArray(keynames::Tuple, from::DataFrames.DataFrame)
 ````
 
 #### get/set

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,3 @@
 julia 0.4
+NDSparseData
+Requires

--- a/src/JuliaTS.jl
+++ b/src/JuliaTS.jl
@@ -2,6 +2,7 @@ module JuliaTS
 
 using NDSparseData
 using Base.Dates
+using Requires
 
 import Base: zero, getindex, setindex!, eltype, keys, values, push!, similar, sizehint!, first, last, searchsortedfirst, resize!, copy!,
              select, union, intersect, deepcopy, start, next, done, show, in
@@ -16,5 +17,6 @@ export TArray, window, nrows, ncols, index, index!, Period,
 
 include("utils.jl")
 include("ts.jl")
+include("io.jl")
 
 end # module

--- a/src/io.jl
+++ b/src/io.jl
@@ -1,0 +1,11 @@
+# relies on other packages at present
+# should have built in io functions in future
+
+@require DataFrames begin
+TArray(keynames, df::DataFrames.DataFrame) = TArray(keynames, Pair[n=>df[n] for n in DataFrames.names(df)]...)
+end
+
+@require TimeSeries begin
+TArray(ts::TimeSeries.TimeArray) = TArray((:timestamp,), ts)
+TArray(keynames, ts::TimeSeries.TimeArray) = TArray(keynames, keynames[1]=>ts.timestamp, Pair[symbol(n)=>ts[n].values for n in TimeSeries.colnames(ts)]...)
+end

--- a/src/ts.jl
+++ b/src/ts.jl
@@ -26,7 +26,9 @@ end
 
 function TArray(keynames::Tuple, colpairs::Pair...)
     raw_data = Dict(colpairs...)
-    valnames = tuple(setdiff([c.first for c in colpairs], keynames)...)
+    colnames = [c.first for c in colpairs]
+    notkey = [!(c in keynames) for c in colnames]
+    valnames = tuple(colnames[notkey]...)
     valcols = [raw_data[c] for c in valnames]
     keycols = [raw_data[c] for c in keynames]
 


### PR DESCRIPTION
``` julia
# from TimeArray, key is always set to :timestamp
TArray(from::TimeSeries.TimeArray)
TArray(keynames::Tuple, from::TimeSeries.TimeArray)
TArray(keynames::Tuple, from::DataFrames.DataFrame)
```

Also maintain column order in constructors

fixes #4 
